### PR TITLE
Include js folder in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "files": [
     "tools",
+    "js",
     "index.js",
     "src",
     "binding.gyp"


### PR DESCRIPTION
You forgot to include the js folder...


![bildschirmfoto 2018-07-26 um 17 17 23](https://user-images.githubusercontent.com/4586894/43271538-1333add4-90f8-11e8-91e8-0aa5c10ec08c.png)


```
Error: Cannot find module './js/checkbox'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (.../screenshot-tester/example/node_modules/libui-napi/index.js:33:22)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```